### PR TITLE
Remove illegal chars from filename. Fix #16

### DIFF
--- a/toutv-cli.py
+++ b/toutv-cli.py
@@ -404,7 +404,7 @@ class ToutvConsoleApp():
 
         if not os.path.exists(os.path.expanduser(directory)):
             os.mkdir(os.path.expanduser(directory))
-			
+
         # Remove illegal chars from filename
         valid_chars = "-_.() %s%s" % (string.ascii_letters, string.digits)
         filename = emission.Title + "-" + episode.Title + ".ts"


### PR DESCRIPTION
I took the whitelist approach as recommended on this [StackOverflow question](http://stackoverflow.com/questions/295135/turn-a-string-into-a-valid-filename-in-python).
