### PR TITLE
fixed XDG cache linux

### DIFF
--- a/toutv-cli.py
+++ b/toutv-cli.py
@@ -38,7 +38,7 @@ import struct
 import textwrap
 import re
 import string
-import xdg.BaseDirectory
+import platform
 
 from toutv import client, cache, m3u8, progressbar
 
@@ -97,10 +97,22 @@ class ToutvConsoleApp():
 
     def build_toutvclient(self):
         transport_impl = client.TransportJson()
-        cache_impl = cache.CacheShelve(
-            os.path.join(
-                xdg.BaseDirectory.save_cache_path('toutv'),
-                '.toutv_cache.txt'))
+
+        if platform.system() == 'Linux':
+            try:
+                if not os.path.exists(os.environ['XDG_CACHE_DIR'] + '/toutv'):
+                    os.makedirs(os.environ['XDG_CACHE_DIR'] + '/toutv')
+                cache_impl = cache.CacheShelve(
+                    os.environ['XDG_CACHE_DIR'] + '/toutv/.toutv_cache')
+            except KeyError:
+                if not os.path.exists(
+                    os.environ['HOME'] + '/.cache/toutv'):
+                    os.makedirs(
+                        os.environ['HOME'] + '/.cache/toutv')
+                cache_impl = cache.CacheShelve(
+                    os.environ['HOME'] + '/.cache/toutv/.toutv_cache')
+        else:
+            cache_impl = cache.CacheShelve(".toutv_cache")
 
         toutvclient = client.ToutvClient(transport_impl, cache_impl)
 


### PR DESCRIPTION
I fixed the issue with the cache on Linux. As you can see, if you merge this as it is, I'll crash on Windows.

I don't know anything about Windows, so I did not fix that issue.

NB: the new cache file is .toutv_cache.txt because without extension XDG created a directory and not a file.
