### PR TITLE
Returned object "seach" corrected to "search"

### DIFF
--- a/toutv/client.py
+++ b/toutv/client.py
@@ -114,7 +114,7 @@ class Client:
         search = self._transport.search(query)
         self._set_bo_proxies(search)
 
-        return seach
+        return search
 
     def get_emission_by_name(self, emission_name):
         emissions = self.get_emissions()


### PR DESCRIPTION
As to match previously declared "search"
