### PR TITLE
Fix crash on floating point segment duration

### DIFF
--- a/toutv/m3u8.py
+++ b/toutv/m3u8.py
@@ -220,7 +220,7 @@ def parse(data, base_uri):
             duration, title = attributes.split(',')
             segment = Segment()
             segment.key = current_key
-            segment.duration = int(duration.strip())
+            segment.duration = float(duration.strip())
             segment.title = title.strip()
             segment.uri = lines[count + 1]
             if _line_is_relative_uri(segment.uri):


### PR DESCRIPTION
I just ran into a segment with a floating point duration which caused a crash. Apparently segment durations should be floating point anyway:
https://developer.apple.com/library/ios/technotes/tn2288/_index.html#//apple_ref/doc/uid/DTS40012238-CH1-DontLinkElementID_3
