### PR TITLE
add straightforward example for a single episode

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -273,6 +273,12 @@ Voici quelques exemples d'utilisation de l'interface en ligne de commande.
         * 1324 kbps
 
 
+### Téléchargement d'un épisode
+
+    $ toutv fetch Enquete S2014E11
+    Enquête.S2014E11.La.guerre.d...    28.8 MiB    24/260 [##-----------------]   9%
+
+
 ### Téléchargement d'un épisode avec la meilleure qualité vidéo disponible
 
     $ toutv fetch -q MAX 'série noire' s01e05

--- a/README.md
+++ b/README.md
@@ -275,6 +275,11 @@ Here are a few CLI usage examples.
         * 925 kbps
         * 1324 kbps
 
+### Fetching an episode
+
+    $ toutv fetch Enquete S2014E11
+    Enquête.S2014E11.La.guerre.d...    28.8 MiB    24/260 [##-----------------]   9%
+
 
 ### Fetching an episode at maximum available video quality
 


### PR DESCRIPTION
i had to look into the usage and puzzle a bit before figuring that one out. i tried all of those without success:

```
$ toutv fetch 2425154539
Cannot find "2425154539"
Did you mean one of the following?

  * 2424965939
  * 2424965839
  * 2421265159
anarcat@marcos:tv$ toutv fetch "S2014E11 La guerre des bois"
Cannot find "S2014E11 La guerre des bois"
Did you mean one of the following?

  * LA GUERRE DES ROBOTS
  * LA GUERRE DES OPOSSUMS
anarcat@marcos:tv$ toutv fetch Enquete 2425154539
Cannot find "Enquete"
Did you mean one of the following?

  * ENQUÊTE
  * BURQUETTE
anarcat@marcos:tv$ toutv fetch Enquete S2014E11
Cannot find "Enquete"
Did you mean one of the following?

  * ENQUÊTE
  * BURQUETTE
```

It would have been helpful to have this documentation in the README to help me out...
