### PR TITLE
Make get_emissions return a list and not use the old API

### DIFF
--- a/toutv/cache.py
+++ b/toutv/cache.py
@@ -72,7 +72,7 @@ class EmptyCache(Cache):
 
 class ShelveCache(Cache):
 
-    _cache_version = 1
+    _cache_version = 2
 
     def __init__(self, shelve_filename):
         self._logger = logging.getLogger(self.__class__.__name__)

--- a/toutv/client.py
+++ b/toutv/client.py
@@ -91,8 +91,8 @@ class Client:
             emissions = self._transport.get_emissions()
             self._cache.set_emissions(emissions)
 
-        self._set_bos_proxies(emissions.values())
-        self._set_bos_auth(emissions.values())
+        self._set_bos_proxies(emissions)
+        self._set_bos_auth(emissions)
 
         return emissions
 
@@ -110,27 +110,6 @@ class Client:
 
         return episodes
 
-    def get_page_repertoire(self):
-        # Get repertoire emissions
-        page_repertoire = self._cache.get_page_repertoire()
-        if page_repertoire is None:
-            page_repertoire = self._transport.get_page_repertoire()
-            self._cache.set_page_repertoire(page_repertoire)
-        rep_em = page_repertoire.get_emissions()
-
-        # Get all emissions (contain more infos) to match them
-        all_em = self.get_emissions()
-
-        # Get more infos for repertoire emissions
-        emissions = {k: all_em[k] for k in all_em if k in rep_em}
-        page_repertoire.set_emissions(emissions)
-
-        # Set proxies
-        self._set_bos_proxies(emissions.values())
-        self._set_bos_auth(emissions.values())
-
-        return page_repertoire
-
     def search(self, query):
         search = self._transport.search(query)
         self._set_bo_proxies(search)
@@ -138,7 +117,7 @@ class Client:
         # Add local emissions (to find Extra emissions & episodes)
         emissions = self.get_emissions()
         query_upper = query.upper()
-        for emid, emission in emissions.items():
+        for emission in emissions:
             if query_upper in emission.get_title().upper():
                 sr = toutv.bos.SearchResultData()
                 sr.Emission = emission
@@ -159,8 +138,8 @@ class Client:
         candidates = []
 
         # Fill candidates
-        for emid, emission in emissions.items():
-            candidates.append(str(emid))
+        for emission in emissions:
+            candidates.append(str(emission.get_id()))
             candidates.append(emission.get_title().upper())
 
         # Get close matches
@@ -176,8 +155,8 @@ class Client:
             raise NoMatchException(emission_name, close_matches)
 
         # Exact match
-        for emid, emission in emissions.items():
-            exact_matches = [str(emid), emission.get_title().upper()]
+        for emission in emissions:
+            exact_matches = [emission.get_id(), emission.get_title().upper()]
             if emission_name_upper in exact_matches:
                 return emission
 

--- a/toutv/transport.py
+++ b/toutv/transport.py
@@ -85,39 +85,30 @@ class JsonTransport(Transport):
         return json['d']
 
     def get_emissions(self):
-        emissions = {}
+        emissions = []
 
         # All emissions, including those only available in Extra
         # We don't have much information about them, except their id, title, and URL, but that is enough to be able to fetch them at least.
         url = '{}/presentation/search'.format(toutv.config.TOUTV_BASE_URL)
         params = {'v': 2, 'd': 'android'}
         results_dto = self._do_query_json_url(url, params)
-        for a_dto in results_dto:
-            if a_dto['Key'].startswith("program-"):
-                emission = toutv.bos.Emission()
-                emission.Title = a_dto['DisplayText']
-                emission.Id = a_dto['Id']
-                emission.Url = a_dto['Url']
-                emissions[emission.Id] = emission
-            else:
-                episode = toutv.bos.Episode()
-                episode.Title = a_dto['DisplayText'].replace("%s - " % emission.Title, "")
-                episode.Id = a_dto['Id']
-                episode.Url = a_dto['Url']
-                url_parts = episode.Url.split('/')
-                episode.SeasonAndEpisode = url_parts[len(url_parts)-1].upper()
-                episode.set_emission(emission)
-                emission.add_episode(episode)
 
-        emissions_dto = self._do_query_json_endpoint('GetEmissions')
-        for emission_dto in emissions_dto:
-            emission = self._mapper.dto_to_bo(emission_dto, bos.Emission)
-            if emission.Id in emissions:
-                for epid, episode in emissions[emission.Id].get_episodes().items():
-                    emission.add_episode(episode)
-            emissions[emission.Id] = emission
+        def dto_to_bo(dto):
+            bo = toutv.bos.Emission()
 
-        return emissions
+            bo.Title = dto['DisplayText']
+            bo.Id = dto['Id']
+            bo.Url = dto['Url']
+
+            return bo
+
+        def filter_program(dto):
+            return dto['Key'].startswith('program-')
+
+        programs_dto = filter(filter_program, results_dto)
+        emissions = map(dto_to_bo, programs_dto)
+
+        return list(emissions)
 
     def get_emission_episodes(self, emission, short_version=False):
         if short_version:

--- a/toutvcli/app.py
+++ b/toutvcli/app.py
@@ -199,8 +199,6 @@ using its name, url or id (as found with the form 1 of this command).
                            usage=usage, description=desc)
         pl.add_argument('show', action='store', nargs='?', type=str,
                         help='Name or url of a show')
-        pl.add_argument('-a', '--all', action='store_true',
-                        help='List shows without episodes')
         pl.add_argument('-n', '--no-cache', action='store_true',
                         help=argparse.SUPPRESS)
         pl.set_defaults(func=self._command_list)
@@ -473,7 +471,7 @@ command. The episode can be specified using its name, number or id.
             self._print_list_episodes(show)
         else:
             # List shows.
-            self._print_list_emissions(args.all)
+            self._print_list_emissions()
 
     def _command_info(self, args):
         first = getattr(args, App.FETCH_INFO_FIRST_ARG)
@@ -558,22 +556,15 @@ command. The episode can be specified using its name, number or id.
 
             print('\n')
 
-    def _print_list_emissions(self, _all=False):
-        if _all:
-            emissions = self._toutv_client.get_emissions()
-        else:
-            repertoire = self._toutv_client.get_page_repertoire()
-            emissions = repertoire.get_emissions()
+    def _print_list_emissions(self):
+        shows = self._toutv_client.get_emissions()
 
-        emissions_keys = list(emissions.keys())
+        def title_sort_func(show):
+            return locale.strxfrm(show.get_title())
 
-        def title_sort_func(ekey):
-            return locale.strxfrm(emissions[ekey].get_title())
-
-        emissions_keys.sort(key=title_sort_func)
-        for ekey in emissions_keys:
-            title = emissions[ekey].get_title()
-            print('{} - {}'.format(ekey, title))
+        for show in sorted(shows, key=title_sort_func):
+            title = show.get_title()
+            print('{} - {}'.format(show.get_id(), title))
 
     def _print_list_episodes(self, emission):
         episodes = self._toutv_client.get_emission_episodes(emission, True)


### PR DESCRIPTION
This patch makes get_emissions stop using the old API.  The new API
returns everything we need for basic operations, and is much more
reliable.

Also, change it so that it returns a list of Emission instead of a dict.