### PR TITLE
Stop using the v1 API for fetching episode lists

### DIFF
--- a/toutv/bos.py
+++ b/toutv/bos.py
@@ -229,7 +229,7 @@ class Emission(_AbstractEmission, _ThumbnailProvider):
         self._episodes[episode.Id] = episode
 
     def get_episodes(self):
-        return self._episodes
+        return self._episodes.values()
 
     def get_title(self):
         return self.Title

--- a/toutv/cache.py
+++ b/toutv/cache.py
@@ -72,7 +72,7 @@ class EmptyCache(Cache):
 
 class ShelveCache(Cache):
 
-    _cache_version = 2
+    _cache_version = 3
 
     def __init__(self, shelve_filename):
         self._logger = logging.getLogger(self.__class__.__name__)

--- a/toutv/client.py
+++ b/toutv/client.py
@@ -105,8 +105,8 @@ class Client:
             if short_version:
                 self._cache.set_emission_episodes(emission, episodes)
 
-        self._set_bos_proxies(episodes.values())
-        self._set_bos_auth(episodes.values())
+        self._set_bos_proxies(episodes)
+        self._set_bos_auth(episodes)
 
         return episodes
 
@@ -127,7 +127,7 @@ class Client:
                     sr.Emission = emission
                     search.Results.append(sr)
 
-                    for epid, episode in episodes.items():
+                    for episode in episodes:
                         sr = toutv.bos.SearchResultData()
                         sr.Episode = episode
                         search.Results.append(sr)
@@ -173,8 +173,8 @@ class Client:
         episode_name_upper = episode_name.upper()
         candidates = []
 
-        for epid, episode in episodes.items():
-            candidates.append(str(epid))
+        for episode in episodes:
+            candidates.append(str(episode.get_id()))
             candidates.append(episode.get_title().upper())
             candidates.append(episode.get_sae())
 
@@ -191,9 +191,9 @@ class Client:
             raise NoMatchException(episode_name, close_matches)
 
         # Got an exact match
-        for epid, episode in episodes.items():
+        for episode in episodes:
             search_items = [
-                str(epid),
+                str(episode.get_id()),
                 episode.get_title().upper(),
                 episode.get_sae()
             ]

--- a/toutv/transport.py
+++ b/toutv/transport.py
@@ -110,15 +110,17 @@ class JsonTransport(Transport):
 
     def get_emission_episodes(self, emission, short_version=False):
         if short_version:
-            if len(emission.get_episodes()) > 0:
-                return emission.get_episodes()
+            episodes = emission.get_episodes()
+            if len(episodes) > 0:
+                return episodes
 
-        episodes = {}
+        episodes = []
 
         url = '{}/presentation/{}'.format(toutv.config.TOUTV_BASE_URL, emission.Url)
         params = {'v': 2, 'excludeLineups': False, 'd': 'android'}
         emission_dto = self._do_query_json_url(url, params)
         seasons = emission_dto['SeasonLineups']
+
         for season in seasons:
             episodes_dto = season['LineupItems']
             for episode_dto in episodes_dto:
@@ -134,15 +136,7 @@ class JsonTransport(Transport):
                 episode.CategoryId = emission.Id
                 episode.SeasonAndEpisode = toutv.client.Client._find_last(r'/.*/(.*)$', episode_dto['Url'])
                 episode.set_emission(emission)
-                episodes[episode.Id] = episode
-
-        if len(episodes) == 0:
-            params = {'emissionid': str(emission.Id)}
-            episodes_dto = self._do_query_json_endpoint('GetEpisodesForEmission', params)
-            for episode_dto in episodes_dto:
-                episode = self._mapper.dto_to_bo(episode_dto, bos.Episode)
-                episode.set_emission(emission)
-                episodes[episode.Id] = episode
+                episodes.append(episode)
 
         return episodes
 

--- a/toutvcli/app.py
+++ b/toutvcli/app.py
@@ -793,7 +793,7 @@ command. The episode can be specified using its name, number or id.
         def episode_sort_func(episode):
             return distutils.version.LooseVersion(episode.get_sae())
 
-        return sorted(episodes.values(), key=episode_sort_func)
+        return sorted(episodes, key=episode_sort_func)
 
 
 def _register_sigint():

--- a/toutvqt/infos_frame.py
+++ b/toutvqt/infos_frame.py
@@ -261,7 +261,7 @@ class _QEmissionInfosWidget(_QInfosWidget, _QEmissionCommonInfosWidget):
 
     def _on_dl_btn_clicked(self):
         episodes = self._client.get_emission_episodes(self._bo)
-        self.select_download.emit(list(episodes.values()))
+        self.select_download.emit(list(episodes))
 
 
 class _QSeasonInfosWidget(_QInfosWidget, _QEmissionCommonInfosWidget):


### PR DESCRIPTION
Stop using the old API for getting a episodes of a show, only rely on
the new one.  Also, make get_emission_episodes return a list instead of
a dict.

Fixes #63