### PR TITLE
Unneeded api calls

### DIFF
--- a/toutv/auth.py
+++ b/toutv/auth.py
@@ -37,21 +37,24 @@ class Auth:
 
     def __init__(self, token=None):
         self._token = token
+        self._claims = None
 
     def get_claims(self, token):
-        headers = {
-            "Authorization": "Bearer " + token,
-            "User-Agent": toutv.config.USER_AGENT,
-            "Accept": "application/json",
-            "Host": "services.radio-canada.ca",
-        }
+        if not self._claims:
+            headers = {
+                "Authorization": "Bearer " + token,
+                "User-Agent": toutv.config.USER_AGENT,
+                "Accept": "application/json",
+                "Host": "services.radio-canada.ca",
+            }
 
-        r = requests.get(toutv.config.TOUTV_AUTH_CLAIMS_URL.format(token), headers=headers)
+            r = requests.get(toutv.config.TOUTV_AUTH_CLAIMS_URL.format(token), headers=headers)
 
-        if r.status_code != 200:
-            raise toutv.exceptions.UnexpectedHttpStatusCodeError(toutv.config.TOUTV_AUTH_CLAIMS_URL.format(token), r.status_code)
+            if r.status_code != 200:
+                raise toutv.exceptions.UnexpectedHttpStatusCodeError(toutv.config.TOUTV_AUTH_CLAIMS_URL.format(token), r.status_code)
 
-        return r.json()["claims"]
+            self._claims = r.json()["claims"]
+        return self._claims
 
     def get_token(self):
         return self._token

--- a/toutv/bos.py
+++ b/toutv/bos.py
@@ -545,7 +545,7 @@ class Episode(_Bo, _ThumbnailProvider):
             # parse M3U8 file
             m3u8_file = r.text
             self._playlist = toutv.m3u8.parse(m3u8_file, os.path.dirname(url))
-            self._cookies = r.cookies;
+            self._cookies = r.cookies
 
         return self._playlist, self._cookies
 

--- a/toutv/bos.py
+++ b/toutv/bos.py
@@ -423,6 +423,8 @@ class Episode(_Bo, _ThumbnailProvider):
         self.UrlEmission = None
         self.Year = None
         self.iTunesLinkUrl = None
+        self._playlist = None
+        self._cookies = None
 
     def get_title(self):
         return self.Title
@@ -536,14 +538,16 @@ class Episode(_Bo, _ThumbnailProvider):
                     raise RuntimeError("Error: GetPlaylistURL failed.") from e
 
     def get_playlist_cookies(self):
-        url = self._get_playlist_url()
-        r = self._do_request(url)
+        if not self._playlist or not self._cookies:
+            url = self._get_playlist_url()
+            r = self._do_request(url)
 
-        # parse M3U8 file
-        m3u8_file = r.text
-        playlist = toutv.m3u8.parse(m3u8_file, os.path.dirname(url))
+            # parse M3U8 file
+            m3u8_file = r.text
+            self._playlist = toutv.m3u8.parse(m3u8_file, os.path.dirname(url))
+            self._cookies = r.cookies;
 
-        return playlist, r.cookies
+        return self._playlist, self._cookies
 
     def get_available_qualities(self):
         # Get playlist

--- a/toutv/cache.py
+++ b/toutv/cache.py
@@ -72,7 +72,7 @@ class EmptyCache(Cache):
 
 class ShelveCache(Cache):
 
-    _cache_version = 3
+    _cache_version = 4
 
     def __init__(self, shelve_filename):
         self._logger = logging.getLogger(self.__class__.__name__)

--- a/toutv/dl.py
+++ b/toutv/dl.py
@@ -434,8 +434,8 @@ class Downloader:
     def download(self):
         self._logger.debug('starting download')
 
-        self._seg_provider.initialize()
         self._seg_handler.initialize()
+        self._seg_provider.initialize()
 
         # Get the number of segments.
         num_segments = self._seg_provider.num_segments()


### PR DESCRIPTION
Removed duplicate API calls to load the Claims, and the playlist & cookies.

Also inverted the segments handler & provider initialization in order to not make unnecessary API calls when the local file already exists, and we won't overwrite.

Fixes #104