### PR TITLE
Better filenames for downloaded files

### DIFF
--- a/toutv/dl.py
+++ b/toutv/dl.py
@@ -27,7 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import re
 import os
 import errno
 import struct
@@ -114,15 +113,15 @@ class FilesystemSegmentHandler(SegmentHandler):
     def __init__(self,
                  episode,
                  bitrate,
-                 filename_qualifier,
                  output_dir,
+                 filename,
                  overwrite=False):
         self._episode = episode
         self._bitrate = bitrate
         self._output_dir = output_dir
         self._overwrite = overwrite
 
-        self._filename = self._gen_filename(filename_qualifier)
+        self._filename = filename
         self._output_path = os.path.join(self._output_dir, self._filename)
 
         self._logger = logging.getLogger(self.__class__.__name__)
@@ -138,24 +137,6 @@ class FilesystemSegmentHandler(SegmentHandler):
     @property
     def output_dir(self):
         return self._output_dir
-
-    def _gen_filename(self, filename_qualifier):
-        emission_title = self._episode.get_emission().Title
-        episode_title = self._episode.Title
-
-        if self._episode.SeasonAndEpisode is not None:
-            sae = self._episode.SeasonAndEpisode
-            episode_title = '{} {}'.format(sae, episode_title)
-
-        episode_title = '{}.{}'.format(episode_title, filename_qualifier)
-        filename = '{}.{}.ts'.format(emission_title, episode_title)
-
-        # remove illegal characters from filename
-        regex = r'[^ \'a-zA-Z0-9áàâäéèêëíìîïóòôöúùûüÁÀÂÄÉÈÊËÍÌÎÏÓÒÔÖÚÙÛÜçÇ()._-]'
-        filename = re.sub(regex, '', filename)
-        filename = re.sub(r'\s', '.', filename)
-
-        return filename
 
     def _get_segment_file_path(self, segindex):
         fmt = '.toutv-{}-{}-{}-{}.ts'

--- a/toutv/dl.py
+++ b/toutv/dl.py
@@ -114,6 +114,7 @@ class FilesystemSegmentHandler(SegmentHandler):
     def __init__(self,
                  episode,
                  bitrate,
+                 filename_qualifier,
                  output_dir,
                  overwrite=False):
         self._episode = episode
@@ -121,7 +122,7 @@ class FilesystemSegmentHandler(SegmentHandler):
         self._output_dir = output_dir
         self._overwrite = overwrite
 
-        self._filename = self._gen_filename()
+        self._filename = self._gen_filename(filename_qualifier)
         self._output_path = os.path.join(self._output_dir, self._filename)
 
         self._logger = logging.getLogger(self.__class__.__name__)
@@ -138,7 +139,7 @@ class FilesystemSegmentHandler(SegmentHandler):
     def output_dir(self):
         return self._output_dir
 
-    def _gen_filename(self):
+    def _gen_filename(self, filename_qualifier):
         emission_title = self._episode.get_emission().Title
         episode_title = self._episode.Title
 
@@ -146,8 +147,7 @@ class FilesystemSegmentHandler(SegmentHandler):
             sae = self._episode.SeasonAndEpisode
             episode_title = '{} {}'.format(sae, episode_title)
 
-        br = self._bitrate // 1000
-        episode_title = '{} {}kbps'.format(episode_title, br)
+        episode_title = '{}.{}'.format(episode_title, filename_qualifier)
         filename = '{}.{}.ts'.format(emission_title, episode_title)
 
         # remove illegal characters from filename

--- a/toutvcli/app.py
+++ b/toutvcli/app.py
@@ -711,18 +711,21 @@ command. The episode can be specified using its name, number or id.
         # Get available bitrates for episode
         qualities = episode.get_available_qualities()
 
+        filename_qualifier = "qAVG"
         # Choose bitrate
         if bitrate is None:
             if quality == App.QUALITY_MIN:
                 bitrate = qualities[0].bitrate
+                filename_qualifier = "qMIN"
             elif quality == App.QUALITY_MAX:
                 bitrate = qualities[-1].bitrate
+                filename_qualifier = "qMAX"
             elif quality == App.QUALITY_AVG:
                 bitrate = App._get_average_bitrate(qualities)
 
         # Create segment handler
         self._seg_handler = toutv.dl.FilesystemSegmentHandler(
-            episode=episode, bitrate=bitrate, output_dir=output_dir,
+            episode=episode, bitrate=bitrate, filename_qualifier=filename_qualifier, output_dir=output_dir,
             overwrite=overwrite)
 
         seg_provider = toutv.dl.ToutvApiSegmentProvider(

--- a/toutvcli/tests/test_app_real.py
+++ b/toutvcli/tests/test_app_real.py
@@ -71,5 +71,5 @@ class ToutvCliAppRealTest(unittest.TestCase):
             os.unlink(file)
 
     def testFetch(self):
-        self._testFetch('Coup.de.pouce.*.S2012E01.*.01.*kbps.ts',
+        self._testFetch('Coup.de.pouce.*.S2012E01.*.01.qMIN.ts',
                         ['COUP DE POUCE POUR LA PLANÈTE', 'S2012E01'])


### PR DESCRIPTION
Instead of including the bitrate in the filename, include qMIN, qMAX or qAVG instead, which reflects the quality setting the user chose for the fetch command.
This will prevent duplicate downloads when tou.tv streams change bitrates.

Fixes #107