### PR TITLE
Print date in episode list

### DIFF
--- a/toutvcli/app.py
+++ b/toutvcli/app.py
@@ -584,7 +584,8 @@ command. The episode can be specified using its name, number or id.
         for episode in App._sort_episodes(episodes):
             sae = episode.get_sae()
             title = episode.get_title()
-            print('  * {} - {} - {}'.format(episode.Id, sae, title))
+            date = episode.get_air_date()
+            print('  * {} - {} - {}'.format(sae, title, date))
 
     def _print_info_emission(self, emission):
         if emission.get_description() is None:


### PR DESCRIPTION
I think it would be useful to have the date in the episode list.  It
helps to know whether the latest episode is new.  Also, I think we can
hide the Id.  It's much more user friendly to refer to episodes using
the SAE.

Before:

  * 2425172033 - S17E25 - Épisode 25

After:

  * S17E25 - Épisode 25 - 9 mars 2017

The date comes already formatted like this from the JSON (in french).
Ideally, we should parse and to make it a "date" Python object and print
it using the user locale, but I think this is good enough for now.