### PR TITLE
tests: Call setup.py test instead of pytest directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install .
   - pip install flake8
 # command to run tests
-script: pytest
+script: python setup.py test
 
 # Static analysis
 before_script:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,9 @@ package_data = {
 install_requires = [
     'pycrypto>=2.0.0',
     'requests>=2.0.0',
-    'setuptools>=3.0'
+    'setuptools>=3.0',
+    # Workaround for bug on Travis with Python nightly
+    'setuptools_scm',
 ]
 
 setup_requires = [


### PR DESCRIPTION
With Python 3.3 on Travis, pytest is not found.  Going through setup.py
to run the tests should make it install pytest, because it is specified
in tests_require, in setup.py.